### PR TITLE
feat: enhance tcp conn rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Use alpine as minimal base image to package the manager and network inspection binaries
 FROM --platform=$TARGETPLATFORM alpine:latest AS production
 WORKDIR /
-RUN apk add --no-cache bind-tools iputils netcat-openbsd
+RUN apk add --no-cache bind-tools iputils
 COPY --from=builder /workspace/manager .
 USER 65532:65532
 

--- a/Dockerfile.devspace
+++ b/Dockerfile.devspace
@@ -3,7 +3,7 @@ FROM --platform=$TARGETPLATFORM golang:1.22-alpine3.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache bash bind-tools git iputils netcat-openbsd
+RUN apk add --no-cache bash bind-tools git iputils
 
 # Install Delve for debugging
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
@@ -22,6 +22,5 @@ COPY api/ api/
 COPY internal/ internal/
 
 # Copy net-utils binaries into /workspace
-RUN cp /usr/bin/nc . && \
-    cp /usr/bin/nslookup . && \
+RUN cp /usr/bin/nslookup . && \
     cp /bin/ping .

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ IMG ?= quay.io/validator-labs/validator-plugin-network:latest
 
 # Helm vars
 CHART_NAME=validator-plugin-network
+
+dev:
+	devspace dev -n validator-plugin-network-system

--- a/api/v1alpha1/networkvalidator_types.go
+++ b/api/v1alpha1/networkvalidator_types.go
@@ -150,6 +150,9 @@ type TCPConnRule struct {
 	// InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
 	// Defaults to false.
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
+	// Timeout is the duration to wait, in seconds, for a connection to be established. Defaults to 5 seconds.
+	// +kubebuilder:default=5
+	Timeout int `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 // Name returns the name of a TCPConnRule.

--- a/api/v1alpha1/networkvalidator_types.go
+++ b/api/v1alpha1/networkvalidator_types.go
@@ -147,11 +147,9 @@ type TCPConnRule struct {
 	RuleName string `json:"name" yaml:"name"`
 	Host     string `json:"host" yaml:"host"`
 	Ports    []int  `json:"ports" yaml:"ports"`
-	// +kubebuilder:validation:Pattern=`^(4|5|connect)?$`
-	ProxyProtocol string `json:"proxyProtocol,omitempty" yaml:"proxyProtocol,omitempty"`
-	ProxyAddress  string `json:"proxyAddress,omitempty" yaml:"proxyAddress,omitempty"`
-	ProxyPort     int    `json:"proxyPort,omitempty" yaml:"proxyPort,omitempty"`
-	// TODO: use socat for proxy validation using TLS CAFile & basic auth?
+	// InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
+	// Defaults to false.
+	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
 }
 
 // Name returns the name of a TCPConnRule.
@@ -167,8 +165,8 @@ type HTTPFileRule struct {
 	// Paths is a list of file paths to check. When performing HTTP requests, if any of the paths result in a non-200 OK response code, the rule fails validation.
 	// +kubebuilder:validation:MaxItems=1000
 	Paths []string `json:"paths" yaml:"paths"`
-	// InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS
-	// certificate verification. Defaults to false.
+	// InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
+	// Defaults to false.
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
 }
 

--- a/api/v1alpha1/networkvalidator_types.go
+++ b/api/v1alpha1/networkvalidator_types.go
@@ -147,9 +147,9 @@ type TCPConnRule struct {
 	RuleName string `json:"name" yaml:"name"`
 	Host     string `json:"host" yaml:"host"`
 	Ports    []int  `json:"ports" yaml:"ports"`
-	// InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
+	// InsecureSkipTLSVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
 	// Defaults to false.
-	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
+	InsecureSkipTLSVerify bool `json:"insecureSkipTlsVerify,omitempty" yaml:"insecureSkipTlsVerify,omitempty"`
 	// Timeout is the duration to wait, in seconds, for a connection to be established. Defaults to 5 seconds.
 	// +kubebuilder:default=5
 	Timeout int `json:"timeout,omitempty" yaml:"timeout,omitempty"`
@@ -168,9 +168,9 @@ type HTTPFileRule struct {
 	// Paths is a list of file paths to check. When performing HTTP requests, if any of the paths result in a non-200 OK response code, the rule fails validation.
 	// +kubebuilder:validation:MaxItems=1000
 	Paths []string `json:"paths" yaml:"paths"`
-	// InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
+	// InsecureSkipTLSVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
 	// Defaults to false.
-	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
+	InsecureSkipTLSVerify bool `json:"insecureSkipTlsVerify,omitempty" yaml:"insecureSkipTlsVerify,omitempty"`
 }
 
 // Name returns the name of a HTTPFileRule.

--- a/config/crd/bases/validation.spectrocloud.labs_networkvalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_networkvalidators.yaml
@@ -104,8 +104,8 @@ spec:
                   properties:
                     insecureSkipVerify:
                       description: |-
-                        InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS
-                        certificate verification. Defaults to false.
+                        InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
+                        Defaults to false.
                       type: boolean
                     name:
                       description: RuleName is a unique identifier for the rule in
@@ -218,6 +218,11 @@ spec:
                   properties:
                     host:
                       type: string
+                    insecureSkipVerify:
+                      description: |-
+                        InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
+                        Defaults to false.
+                      type: boolean
                     name:
                       description: RuleName is a unique identifier for the rule in
                         the validator. Used to ensure conditions do not overwrite
@@ -228,13 +233,6 @@ spec:
                       items:
                         type: integer
                       type: array
-                    proxyAddress:
-                      type: string
-                    proxyPort:
-                      type: integer
-                    proxyProtocol:
-                      pattern: ^(4|5|connect)?$
-                      type: string
                   required:
                   - host
                   - name

--- a/config/crd/bases/validation.spectrocloud.labs_networkvalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_networkvalidators.yaml
@@ -102,9 +102,9 @@ spec:
                 items:
                   description: HTTPFileRule defines an HTTP file rule.
                   properties:
-                    insecureSkipVerify:
+                    insecureSkipTlsVerify:
                       description: |-
-                        InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
+                        InsecureSkipTLSVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
                         Defaults to false.
                       type: boolean
                     name:
@@ -218,9 +218,9 @@ spec:
                   properties:
                     host:
                       type: string
-                    insecureSkipVerify:
+                    insecureSkipTlsVerify:
                       description: |-
-                        InsecureSkipVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
+                        InsecureSkipTLSVerify controls whether the HTTP client used validate the rule skips TLS certificate verification.
                         Defaults to false.
                       type: boolean
                     name:

--- a/config/crd/bases/validation.spectrocloud.labs_networkvalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_networkvalidators.yaml
@@ -233,6 +233,11 @@ spec:
                       items:
                         type: integer
                       type: array
+                    timeout:
+                      default: 5
+                      description: Timeout is the duration to wait, in seconds, for
+                        a connection to be established. Defaults to 5 seconds.
+                      type: integer
                   required:
                   - host
                   - name

--- a/config/samples/networkvalidator-networkrules.yaml
+++ b/config/samples/networkvalidator-networkrules.yaml
@@ -33,14 +33,37 @@ spec:
     ports:
     - 443
     - 4222
-  - name: Palette Saas - proxied
-    host: console.spectrocloud.com
-    ports:
-    - 443
-    proxyProtocol: connect # 4, 5, or 'connect'
-    proxyAddress: "10.10.180.1"
-    proxyPort: 3128
   - name: Invalid host
     host: xprxkddd.fake
     ports:
     - 443
+  - name: Custom CA
+    host: toolbox.palette-adv.spectrocloud.com
+    ports:
+    - 5001
+  caCerts:
+    certs:
+    - |-
+      -----BEGIN CERTIFICATE-----
+      MIID1zCCAr+gAwIBAgIJANxjTMWeqyLTMA0GCSqGSIb3DQEBCwUAMFQxLTArBgNV
+      BAMMJHRvb2xib3gucGFsZXR0ZS1hZHYuc3BlY3Ryb2Nsb3VkLmNvbTELMAkGA1UE
+      BhMCVVMxFjAUBgNVBAcMDVNhbiBGcmFuc2lzY28wHhcNMjMxMjIyMTgyNDAzWhcN
+      MjQxMjIxMTgyNDAzWjCBkzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3Ju
+      aWExFjAUBgNVBAcMDVNhbiBGcmFuc2lzY28xETAPBgNVBAoMCE1Mb3BzSHViMRUw
+      EwYDVQQLDAxNbG9wc0h1YiBEZXYxLTArBgNVBAMMJHRvb2xib3gucGFsZXR0ZS1h
+      ZHYuc3BlY3Ryb2Nsb3VkLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+      ggEBANC9+LKAmVkTHpvJm0DRwOQmJdLpLwwCFBe0+boYdcPgEMeQ5R4fs0bv1yyt
+      9XQICplCHtq44Q2M0yheiqhdLB5e2MbxuREIf1QDCqLBmGbee4WH2+oR+YUhIWla
+      39XNsWsCOOxQWLzTLqWJhXxTHBrcT5GYKvPXAywgZqRZnCt72Bvo3TfG8m7pRJt/
+      oBA6pK4Yo5fHmWIxyBw7JmUdXpe0YDObTS0MFp0d1nsBnXQfRq6v6np2R/KWRs3H
+      VNiajwYKcmpHHRT2gTLXIP5QQHr2Uzg7v/0SEd3Ier29RkjSVmltoFTUBBHgl325
+      bl62cEpNHNzc/A2yuaGTT6wf8AMCAwEAAaNsMGowHwYDVR0jBBgwFoAUcOuja62h
+      hGwZf0z6FH9q7vFBnAkwCQYDVR0TBAIwADALBgNVHQ8EBAMCBPAwLwYDVR0RBCgw
+      JoIkdG9vbGJveC5wYWxldHRlLWFkdi5zcGVjdHJvY2xvdWQuY29tMA0GCSqGSIb3
+      DQEBCwUAA4IBAQAkswhVHeQS3ERkwuxLCts/fitDYHGKTpewSMQpTHHEvC9Fh8SZ
+      c16dELR6GXPG6Rpj4mkHWETU8LZDQ/m3rMlhWPUYedaGIV0vt6UApiBtQdNycVnJ
+      3xVZXt/dsndAZm4Jsd5nNWCTgwudNgRM5uY/xGlXM/D4BiUkU7rVQKEdBTV6NtVh
+      Gvmf+g0LPqyat8vBAfsxBdlHRGS87FOmltpjArKyFEMfoPr9lPJsNT8jamU7lSMt
+      g7kncV3YesyK0O2z6YCwQ/RwFLUmDoj41KhU6hSNfFPUuLxVA10iiM5BH6++7LzL
+      V5r2BXP5LLPyL0KQxzK2FTnfDie1hq014OHn
+      -----END CERTIFICATE-----

--- a/internal/controller/networkvalidator_controller.go
+++ b/internal/controller/networkvalidator_controller.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/validator-labs/validator-plugin-network/api/v1alpha1"
 	"github.com/validator-labs/validator-plugin-network/internal/constants"
-	pluginhttp "github.com/validator-labs/validator-plugin-network/internal/http"
+	"github.com/validator-labs/validator-plugin-network/internal/http"
 	"github.com/validator-labs/validator-plugin-network/internal/secrets"
 	"github.com/validator-labs/validator-plugin-network/internal/validators"
 	vapi "github.com/validator-labs/validator/api/v1alpha1"
@@ -144,7 +144,7 @@ func (r *NetworkValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 			caPems = append(caPems, caPem)
 		}
-		transport, err := pluginhttp.TransportWithCA(caPems, rule.InsecureSkipVerify)
+		transport, err := http.TransportWithCA(caPems, rule.InsecureSkipVerify)
 		if err != nil {
 			resp.AddResult(nil, fmt.Errorf("failed to create HTTP transport: %w", err))
 			continue

--- a/internal/controller/networkvalidator_controller.go
+++ b/internal/controller/networkvalidator_controller.go
@@ -99,6 +99,20 @@ func (r *NetworkValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	networkService := validators.NewNetworkService(r.Log)
 
+	// If CACert config provided, use the inline certs and secret refs.
+	caPems := make([][]byte, 0)
+	for _, cert := range validator.Spec.CACerts.Certs {
+		caPems = append(caPems, []byte(cert))
+	}
+	for _, secretRef := range validator.Spec.CACerts.SecretRefs {
+		caPem, err := secrets.Read(secretRef.Name, req.Namespace, secretRef.Key, r.Client)
+		if err != nil {
+			r.Log.Error(err, "failed to read CA certificate secret")
+			return ctrl.Result{}, err
+		}
+		caPems = append(caPems, caPem)
+	}
+
 	// DNS rules
 	for _, rule := range validator.Spec.DNSRules {
 		vrr := networkService.ReconcileDNSRule(rule)
@@ -125,32 +139,27 @@ func (r *NetworkValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// TCP connection rules
 	for _, rule := range validator.Spec.TCPConnRules {
-		vrr := networkService.ReconcileTCPConnRule(rule)
+		tlsConfig, err := http.TLSConfig(caPems, rule.InsecureSkipVerify, r.Log)
+		if err != nil {
+			vrr := validators.BuildValidationResult(rule, constants.ValidationTypeTCPConn)
+			resp.AddResult(vrr, fmt.Errorf("failed to create TLS config: %w", err))
+			continue
+		}
+		ruleSvc := validators.NewNetworkService(r.Log, validators.WithTLSConfig(tlsConfig))
+		vrr := ruleSvc.ReconcileTCPConnRule(rule)
 		resp.AddResult(vrr, err)
 	}
 
 	// HTTP file rules
 	for _, rule := range validator.Spec.HTTPFileRules {
-		// If CACert config provided, use the inline certs and secret refs.
-		caPems := make([][]byte, 0)
-		for _, cert := range validator.Spec.CACerts.Certs {
-			caPems = append(caPems, []byte(cert))
-		}
-		for _, secretRef := range validator.Spec.CACerts.SecretRefs {
-			caPem, err := secrets.Read(secretRef.Name, req.Namespace, secretRef.Key, r.Client)
-			if err != nil {
-				resp.AddResult(nil, fmt.Errorf("failed to read CA certificate secret: %w", err))
-				continue
-			}
-			caPems = append(caPems, caPem)
-		}
-		transport, err := http.TransportWithCA(caPems, rule.InsecureSkipVerify)
+		transport, err := http.Transport(caPems, rule.InsecureSkipVerify, r.Log)
 		if err != nil {
-			resp.AddResult(nil, fmt.Errorf("failed to create HTTP transport: %w", err))
+			vrr := validators.BuildValidationResult(rule, constants.ValidationTypeHTTPFile)
+			resp.AddResult(vrr, fmt.Errorf("failed to create HTTP transport: %w", err))
 			continue
 		}
-		svc := validators.NewNetworkService(r.Log, validators.WithTransport(transport))
-		vrr := svc.ReconcileHTTPFileRule(rule)
+		ruleSvc := validators.NewNetworkService(r.Log, validators.WithTransport(transport))
+		vrr := ruleSvc.ReconcileHTTPFileRule(rule)
 		resp.AddResult(vrr, err)
 	}
 

--- a/internal/controller/networkvalidator_controller.go
+++ b/internal/controller/networkvalidator_controller.go
@@ -139,7 +139,7 @@ func (r *NetworkValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// TCP connection rules
 	for _, rule := range validator.Spec.TCPConnRules {
-		tlsConfig, err := http.TLSConfig(caPems, rule.InsecureSkipVerify, r.Log)
+		tlsConfig, err := http.TLSConfig(caPems, rule.InsecureSkipTLSVerify, r.Log)
 		if err != nil {
 			vrr := validators.BuildValidationResult(rule, constants.ValidationTypeTCPConn)
 			resp.AddResult(vrr, fmt.Errorf("failed to create TLS config: %w", err))
@@ -152,7 +152,7 @@ func (r *NetworkValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// HTTP file rules
 	for _, rule := range validator.Spec.HTTPFileRules {
-		transport, err := http.Transport(caPems, rule.InsecureSkipVerify, r.Log)
+		transport, err := http.Transport(caPems, rule.InsecureSkipTLSVerify, r.Log)
 		if err != nil {
 			vrr := validators.BuildValidationResult(rule, constants.ValidationTypeHTTPFile)
 			resp.AddResult(vrr, fmt.Errorf("failed to create HTTP transport: %w", err))

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -20,16 +20,18 @@ func TransportWithCA(caPems [][]byte, insecureSkipVerify bool) (*http.Transport,
 		// No error occurred and at least one alternative cert was provided, so start a new pool.
 		caCertPool = x509.NewCertPool()
 	}
-
 	for _, caPem := range caPems {
 		caCertPool.AppendCertsFromPEM(caPem)
 	}
 
-	return &http.Transport{
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: insecureSkipVerify, // #nosec G402
 			RootCAs:            caCertPool,
 			MinVersion:         tls.VersionTLS12,
 		},
-	}, nil
+	}
+
+	return transport, nil
 }

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -6,32 +6,37 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+
+	"github.com/go-logr/logr"
 )
 
-// TransportWithCA creates a new http.Transport with the provided CA certificates and
-// insecureSkipVerify. If loading the system cert pool fails, it must be provided with at least one
-// alternative cert to use. If no alternative certs are provided, the system cert pool must load.
-func TransportWithCA(caPems [][]byte, insecureSkipVerify bool) (*http.Transport, error) {
+// Transport creates a new http.Transport with insecureSkipVerify and optionally, additional CA certificates.
+func Transport(caPems [][]byte, insecureSkipVerify bool, log logr.Logger) (*http.Transport, error) {
+	tlsConfig, err := TLSConfig(caPems, insecureSkipVerify, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TLS config: %w", err)
+	}
+	transport := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsConfig,
+	}
+	return transport, nil
+}
+
+// TLSConfig creates a new tls.Config. If the system cert pool cannot be loaded, an empty pool is used.
+func TLSConfig(caPems [][]byte, insecureSkipVerify bool, log logr.Logger) (*tls.Config, error) {
 	caCertPool, err := x509.SystemCertPool()
 	if err != nil {
-		if len(caPems) == 0 {
-			return nil, fmt.Errorf("failed to get system cert pool and no alternative cert provided: %w", err)
-		}
-		// No error occurred and at least one alternative cert was provided, so start a new pool.
+		log.V(0).Info("failed to load system cert pool, using empty pool", "error", err)
 		caCertPool = x509.NewCertPool()
 	}
 	for _, caPem := range caPems {
 		caCertPool.AppendCertsFromPEM(caPem)
 	}
-
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: insecureSkipVerify, // #nosec G402
-			RootCAs:            caCertPool,
-			MinVersion:         tls.VersionTLS12,
-		},
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify, // #nosec G402
+		RootCAs:            caCertPool,
+		MinVersion:         tls.VersionTLS12,
 	}
-
-	return transport, nil
+	return tlsConfig, nil
 }

--- a/internal/validators/network.go
+++ b/internal/validators/network.go
@@ -38,18 +38,18 @@ type NetworkService struct {
 	log        logr.Logger
 }
 
-// NetworkServiceHTTPClientOption allows customizing the NetworkService's HTTP client.
-type NetworkServiceHTTPClientOption func(*http.Client)
+// HTTPClientOption allows customizing the NetworkService's HTTP client.
+type HTTPClientOption func(*http.Client)
 
 // WithTransport allows callers to optionally provide a custom transport for the HTTP client.
-func WithTransport(transport http.RoundTripper) NetworkServiceHTTPClientOption {
+func WithTransport(transport http.RoundTripper) HTTPClientOption {
 	return func(client *http.Client) {
 		client.Transport = transport
 	}
 }
 
 // NewNetworkService creates a new NetworkService.
-func NewNetworkService(log logr.Logger, opts ...NetworkServiceHTTPClientOption) *NetworkService {
+func NewNetworkService(log logr.Logger, opts ...HTTPClientOption) *NetworkService {
 	// Start with the default HTTP client.
 	client := http.DefaultClient
 

--- a/internal/validators/network.go
+++ b/internal/validators/network.go
@@ -185,8 +185,7 @@ func (n *NetworkService) ReconcileTCPConnRule(rule v1alpha1.TCPConnRule) *types.
 
 	tlsDialer := &tls.Dialer{
 		NetDialer: &net.Dialer{
-			Timeout:   5 * time.Second, // Set a timeout for dialing
-			LocalAddr: nil,             // Use nil to let the system choose the local address
+			Timeout: time.Duration(rule.Timeout) * time.Second,
 		},
 		Config: n.tlsConfig,
 	}

--- a/internal/validators/network_test.go
+++ b/internal/validators/network_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestPublicBlobRuleService_ReconcileHTTPRule2(t *testing.T) {
+func TestReconcileHTTPFileRule(t *testing.T) {
 	testCases := []struct {
 		name           string
 		rule           v1alpha1.HTTPFileRule
@@ -97,7 +97,7 @@ func TestPublicBlobRuleService_ReconcileHTTPRule2(t *testing.T) {
 				Condition: &vapi.ValidationCondition{
 					ValidationType: "http-file",
 					ValidationRule: "rule-1",
-					Message:        "One or more files not publicly accessible. See failures for details.",
+					Message:        "HTTPFile check(s) failed. See failures for details.",
 					Details: []string{
 						"Ensuring that files [{{serverUrl}}/file1] are publicly accessible.",
 					},
@@ -122,7 +122,7 @@ func TestPublicBlobRuleService_ReconcileHTTPRule2(t *testing.T) {
 				Condition: &vapi.ValidationCondition{
 					ValidationType: "http-file",
 					ValidationRule: "rule-1",
-					Message:        "One or more files not publicly accessible. See failures for details.",
+					Message:        "HTTPFile check(s) failed. See failures for details.",
 					Details: []string{
 						"Ensuring that files [{{serverUrl}}/file1] are publicly accessible.",
 					},


### PR DESCRIPTION
## Issue
Addresses #108, among other things.

## Description
- replace `netcat` with custom TLS dialer
- enable configuration for insecureSkipTlsVerify, custom CAs, and timeouts for TCPConn rules
- ensure all validation errors are associated with their respective rule
- improved error handling for HTTPFile rules
