### PR TITLE
chore: assert that PluginSpec is implemented

### DIFF
--- a/api/v1alpha1/networkvalidator_types.go
+++ b/api/v1alpha1/networkvalidator_types.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/validator-labs/validator/pkg/plugins"
 	"github.com/validator-labs/validator/pkg/validationrule"
 
 	"github.com/validator-labs/validator-plugin-network/pkg/constants"
@@ -55,6 +56,8 @@ type NetworkValidatorSpec struct {
 	// CACerts allow additional CA certificates to be used for TLS. Applies to TCPConnRules and HTTPFileRules.
 	CACerts CACertificates `json:"caCerts,omitempty" yaml:"caCerts,omitempty"`
 }
+
+var _ plugins.PluginSpec = (*NetworkValidatorSpec)(nil)
 
 // PluginCode returns the network validator's plugin code.
 func (s NetworkValidatorSpec) PluginCode() string {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
-	github.com/validator-labs/validator v0.1.7
+	github.com/validator-labs/validator v0.1.8
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/validator-labs/validator v0.1.7 h1:x1iBKoecChM52G7bbacMsdIQYvB84C65DRIex8TG6vQ=
-github.com/validator-labs/validator v0.1.7/go.mod h1:ssEvc9ws3kwWJ2VpIsOtgm7WmA6bdux2kkuIHbgT6oU=
+github.com/validator-labs/validator v0.1.8 h1:4PRcnQ92Knao7V0hm704DYQMi0+nNjbS/PgMRCDH2iU=
+github.com/validator-labs/validator v0.1.8/go.mod h1:+8vtI1GlihPKm0Jp61D50KPgkJkFmLZNc5fqh415DuQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
## Issue
Related to https://github.com/validator-labs/validatorctl/issues/178

## Description
Asserts that the PluginSpec interface is implemented
