### PR TITLE
fix: embedding structs related to `validationrule.Interface`

### DIFF
--- a/api/v1alpha1/networkvalidator_types.go
+++ b/api/v1alpha1/networkvalidator_types.go
@@ -109,7 +109,7 @@ func (r CASecretReference) Keys() []string {
 
 // DNSRule defines a DNS validation rule.
 type DNSRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// RuleName is a unique identifier for the rule in the validator. Used to ensure conditions do not overwrite each other.
 	// +kubebuilder:validation:MaxLength=500
@@ -132,7 +132,7 @@ func (r *DNSRule) SetName(name string) {
 
 // ICMPRule defines an ICMP validation rule.
 type ICMPRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// RuleName is a unique identifier for the rule in the validator. Used to ensure conditions do not overwrite each other.
 	// +kubebuilder:validation:MaxLength=500
@@ -154,7 +154,7 @@ func (r *ICMPRule) SetName(name string) {
 
 // IPRangeRule defines an IP range validation rule.
 type IPRangeRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// RuleName is a unique identifier for the rule in the validator. Used to ensure conditions do not overwrite each other.
 	// +kubebuilder:validation:MaxLength=500
@@ -177,7 +177,7 @@ func (r *IPRangeRule) SetName(name string) {
 
 // MTURule defines an MTU validation rule.
 type MTURule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// RuleName is a unique identifier for the rule in the validator. Used to ensure conditions do not overwrite each other.
 	// +kubebuilder:validation:MaxLength=500
@@ -204,7 +204,7 @@ func (r *MTURule) SetName(name string) {
 
 // TCPConnRule defines a TCP connection validation rule.
 type TCPConnRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// RuleName is a unique identifier for the rule in the validator. Used to ensure conditions do not overwrite each other.
 	// +kubebuilder:validation:MaxLength=500
@@ -233,7 +233,7 @@ func (r *TCPConnRule) SetName(name string) {
 
 // HTTPFileRule defines an HTTP file rule. A unique rule must be created for each host requiring HTTP basic authentication.
 type HTTPFileRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// RuleName is a unique identifier for the rule in the validator. Used to ensure conditions do not overwrite each other.
 	// +kubebuilder:validation:MaxLength=500


### PR DESCRIPTION
## Description
Noticed when trying to integrate latest plugin releases with validatorctl that tests started failing because the CRD couldn't be applied. It complained about unknown fields. This is because the json tag used when embedding the struct lacked "inline". This fixes that.
