### PR TITLE
fix: metrics targetPort https -> 8443

### DIFF
--- a/chart/validator-plugin-network/README.md
+++ b/chart/validator-plugin-network/README.md
@@ -24,7 +24,7 @@ The following table lists the configurable parameters of the Validator-plugin-ne
 | `controllerManager.replicas` |  | `1` |
 | `controllerManager.serviceAccount.annotations` |  | `{}` |
 | `kubernetesClusterDomain` |  | `"cluster.local"` |
-| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": "https"}]` |
+| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": 8443}]` |
 | `metricsService.type` |  | `"ClusterIP"` |
 | `env` |  | `[]` |
 | `proxy.enabled` |  | `false` |

--- a/chart/validator-plugin-network/values.yaml
+++ b/chart/validator-plugin-network/values.yaml
@@ -30,7 +30,7 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP
 
 # Optional environment variable configuration


### PR DESCRIPTION
Metrics server is exposed on port 8443. This PR updates the metrics service chart value to match this, to ensure it's accessible.
