### PR TITLE
chore: bump to go1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/validator-labs/validator-plugin-network
 
-go 1.22.5
+go 1.23.6
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
## Description
Bump go versions to address reported security issues.
